### PR TITLE
nginx depends on lizmap service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,4 +43,6 @@ services:
       - ${LIZMAP_DIR}:/srv/lizmap
     ports:
       - 8888:80
+    depends_on:
+      - lizmap
 


### PR DESCRIPTION
Sometimes Nginx tries to start before "lizmap" service and cannot resolve directive in nginx.conf:

"fastcgi_pass  lizmap:9000;" 

on upstart, as "lizmap" hostname is not known yet.