### PR TITLE
Use custom templates in lizmap-docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     volumes:
       - ${LIZMAP_PROJECTS}:/srv/projects
       - ${LIZMAP_DIR}/var/lizmap-theme-config:/www/lizmap/var/lizmap-theme-config
+      - ${LIZMAP_DIR}/var/lizmap-themes-default:/www/lizmap/var/themes/default
       - ${LIZMAP_DIR}/var/lizmap-config:/www/lizmap/var/config
       - ${LIZMAP_DIR}/var/lizmap-db:/www/lizmap/var/db
       - ${LIZMAP_DIR}/www:/www/lizmap/www

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,6 +39,7 @@ _makedirs() {
              $INSTALL_DEST/var/log/nginx \
              $INSTALL_DEST/var/nginx-cache \
              $INSTALL_DEST/var/lizmap-theme-config \
+	     $INSTALL_DEST/var/lizmap-themes-default \
              $INSTALL_DEST/var/lizmap-db \
              $INSTALL_DEST/var/lizmap-config \
              $INSTALL_DEST/var/lizmap-modules \


### PR DESCRIPTION
Update docker-compose.yml
Add - ${LIZMAP_DIR}/var/lizmap-themes-default:/www/lizmap/var/themes/default 
To use custom templates as described in the documentation  https://docs.lizmap.com/current/en/publish/customization/template.html
Additionally, I manually created a directory ${LIZMAP_DIR}/var/lizmap-themes-default in my lizmap-docker directory. 
It would be better to create this directory when installing lizmap-docker-compose - need to make changes to a file entrypoint.sh in section  _makedirs()?

<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* Ticket : #25  
* 
