### PR TITLE
add client_max_body_size parameter

### DIFF
--- a/lizmap.dir/etc/nginx.conf
+++ b/lizmap.dir/etc/nginx.conf
@@ -25,6 +25,7 @@ http {
     tcp_nopush     on;
     tcp_nodelay    on;
     types_hash_max_size 2048;
+    client_max_body_size 8M;
 
     keepalive_timeout  65;
 


### PR DESCRIPTION
It fix a problem since nginx default client_max_body_size is 1MB, with this change it compare the  same value used by PHP in the Lizmap container.
