### PR TITLE
fix: lizmap projects path build form install_dest

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -143,7 +143,7 @@ configure() {
 
     source $INSTALL_SOURCE/env.default
 
-    LIZMAP_PROJECTS=${LIZMAP_PROJECTS:-"$LIZMAP_DIR/instances"}
+    LIZMAP_PROJECTS=${LIZMAP_PROJECTS:-$INSTALL_DEST"/instances"}
     
     docker run -it \
         -u $LIZMAP_UID:$LIZMAP_GID \


### PR DESCRIPTION
refs #90 

LIZMAP_PROJECTS is build now build from INSTALL_DEST (LIZMAP_DIR was undefined)