### PR TITLE
Use PostgreSQL backend for lizLog instead of SQLite

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -84,6 +84,9 @@ fi
 
 _makelizmapprofiles() {
     cat > $INSTALL_DEST/etc/profiles.d/lizmap_local.ini.php <<-EOF
+[jdb]
+lizlog=jauth
+
 [jdb:jauth]
 driver=pgsql
 host=$POSTGIS_ALIAS


### PR DESCRIPTION
The jAuth uses PostgreSQL as backend but not the lizlog.

Funded by Tarre de Provence Agglomération