### PR TITLE
Add optional WebDAV module, on by default in Codespaces

### DIFF
--- a/.devcontainer/docker-compose.codespaces.yml
+++ b/.devcontainer/docker-compose.codespaces.yml
@@ -14,3 +14,12 @@ services:
       # testers can push/pull QGIS projects over WebDAV out of the box. Left
       # off by default for plain local setups — see README.md "WebDAV module".
       LIZMAP_ENABLE_EXTRA_MODULES: '1'
+      # Codespaces terminates HTTPS at its tunnel and forwards plain HTTP to
+      # this container with an internal "Host: localhost:8090" header. Without
+      # telling Lizmap the real public scheme/domain, it generates absolute
+      # URLs (e.g. the WebDAV base URL the QGIS plugin uses to push projects)
+      # pointing at that internal host instead of the Codespace, which then
+      # fails client-side with an SSL handshake error. LIZMAP_PROXYURL_DOMAIN
+      # is computed in .devcontainer/setup.sh from GitHub's own env vars.
+      LIZMAP_PROXYURL_PROTOCOL: https
+      LIZMAP_PROXYURL_DOMAIN: ${LIZMAP_PROXYURL_DOMAIN:-}

--- a/.devcontainer/docker-compose.codespaces.yml
+++ b/.devcontainer/docker-compose.codespaces.yml
@@ -9,3 +9,8 @@ services:
   lizmap:
     environment:
       LIZMAP_ADMIN_DEFAULT_PASSWORD_SOURCE: /srv/etc/admin.conf
+      # Automatically install and activate the modules declared in
+      # var/lizmap-my-packages/composer.json (currently the WebDAV module), so
+      # testers can push/pull QGIS projects over WebDAV out of the box. Left
+      # off by default for plain local setups — see README.md "WebDAV module".
+      LIZMAP_ENABLE_EXTRA_MODULES: '1'

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -16,6 +16,16 @@ MARKER="lizmap/.codespaces-configured"
 export LIZMAP_PORT=8090    # Lizmap web UI
 export POSTGIS_PORT=8093   # PostGIS, so QGIS Desktop can reach it via `gh codespace ports forward`
 
+# The public HTTPS URL GitHub forwards this port to (e.g.
+# https://<name>-8090.app.github.dev). Without this, Lizmap sees the tunnel's
+# internal "Host: localhost:8090" and generates absolute URLs pointing there —
+# notably the WebDAV base URL the QGIS plugin uses to push projects, which then
+# tries to reach the tester's own "localhost:8090" instead of the Codespace and
+# fails with an SSL handshake error. See docker-compose.codespaces.yml.
+if [ -n "${CODESPACE_NAME:-}" ] && [ -n "${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN:-}" ]; then
+  export LIZMAP_PROXYURL_DOMAIN="${CODESPACE_NAME}-${LIZMAP_PORT}.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
+fi
+
 if [ ! -f "$MARKER" ]; then
   echo "▶ Configuring Lizmap (first run, this happens only once)…"
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,37 @@ You need to :
 * in the Lizmap admin panel, add the directory you created
 * add one or more QGIS projects with the Lizmap CFG file in the directory
 
+## WebDAV module
+
+The stack ships with the [Lizmap WebDAV module](https://github.com/3liz/lizmap-webdav-module)
+declared in `lizmap.dir/var/lizmap-my-packages/composer.json`, ready to be installed and
+activated with no manual step — but it is **opt-in** for a plain local stack, and **on by
+default** for the "Open in GitHub Codespaces" online demo.
+
+- **GitHub Codespaces**: enabled automatically (see `LIZMAP_ENABLE_EXTRA_MODULES` in
+  `.devcontainer/docker-compose.codespaces.yml`). Once the Codespace is up, browse projects over
+  WebDAV at `<your-codespace-url>/dav.php/` (basic auth, same credentials as the Lizmap admin
+  account).
+- **Local `docker compose up`**: disabled by default. To turn it on, set
+  `LIZMAP_ENABLE_EXTRA_MODULES=1` before starting the stack, e.g. add it to `lizmap/.env` or run:
+  ```bash
+  LIZMAP_ENABLE_EXTRA_MODULES=1 docker compose up -d
+  ```
+  Then browse WebDAV at `http://localhost:8090/dav.php/`.
+
+Under the hood, the `lizmap` container's entrypoint is wrapped by `lizmap.dir/etc/module-init.sh`.
+When `LIZMAP_ENABLE_EXTRA_MODULES=1`, it runs `composer install` on `var/lizmap-my-packages` and
+configures any newly installed module before starting Lizmap normally. This runs on every
+container start and is a no-op once everything is already installed/configured, so it adds no
+noticeable overhead after the first run. When the variable is unset, the script does nothing and
+Lizmap starts exactly as before.
+
+To add another module the same way, add it to `lizmap.dir/var/lizmap-my-packages/composer.json`
+(and update `composer.lock`, e.g. with
+`docker compose exec lizmap composer update --working-dir=/www/lizmap/my-packages`) — it will be
+installed and configured automatically the next time the stack starts with
+`LIZMAP_ENABLE_EXTRA_MODULES=1`.
+
 ## Reset the configuration
 
 In command line

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
       LIZMAP_CONFIG_INCLUDE: /srv/etc
       PGSERVICEFILE: /srv/etc/pg_service.conf
       PGPASSFILE: /srv/etc/pgpass.conf
+      # Off by default for plain local setups; the Codespaces override turns it on.
+      # See README.md "WebDAV module".
+      LIZMAP_ENABLE_EXTRA_MODULES: ${LIZMAP_ENABLE_EXTRA_MODULES:-0}
     volumes:
       - { type: bind, source: "${LIZMAP_PROJECTS}", target: /srv/projects }
       - { type: bind, source: "${LIZMAP_DIR}/var/lizmap-theme-config", target: /www/lizmap/var/lizmap-theme-config }
@@ -22,6 +25,7 @@ services:
       - { type: bind, source: "${LIZMAP_DIR}/var/lizmap-my-packages", target: /www/lizmap/my-packages }
       - { type: bind, source: "${LIZMAP_DIR}/cache", target: /srv/cache }
       - { type: bind, source: "${LIZMAP_DIR}/etc", target: /srv/etc, read_only: true }
+    entrypoint: ["/srv/etc/module-init.sh"]
     command:
       - php-fpm
     depends_on:

--- a/lizmap.dir/etc/module-init.sh
+++ b/lizmap.dir/etc/module-init.sh
@@ -21,6 +21,19 @@ set -e
 MY_PACKAGES_DIR=/www/lizmap/my-packages
 
 if [ "${LIZMAP_ENABLE_EXTRA_MODULES:-0}" = "1" ] && [ -f "$MY_PACKAGES_DIR/composer.json" ]; then
+    # lizmap-entrypoint.sh normally seeds var/config from var/config.dist before
+    # running the Jelix installer/configurator. Since we run *before* it, do the
+    # same seeding here first: otherwise, on a brand new volume, configurator.php
+    # below would initialize a bare profiles.ini.php missing the [jdb] defaults
+    # (e.g. no driver for the "default" profile), and the real entrypoint would
+    # then skip its own copy since the file already exists. Safe/idempotent to
+    # run twice.
+    CONFIG_DIR=/www/lizmap/var/config
+    cp -aR "$CONFIG_DIR.dist"/* "$CONFIG_DIR"
+    [ ! -f "$CONFIG_DIR/lizmapConfig.ini.php" ] && cp "$CONFIG_DIR/lizmapConfig.ini.php.dist" "$CONFIG_DIR/lizmapConfig.ini.php"
+    [ ! -f "$CONFIG_DIR/localconfig.ini.php" ] && cp "$CONFIG_DIR/localconfig.ini.php.dist" "$CONFIG_DIR/localconfig.ini.php"
+    [ ! -f "$CONFIG_DIR/profiles.ini.php" ] && cp "$CONFIG_DIR/profiles.ini.php.dist" "$CONFIG_DIR/profiles.ini.php"
+
     echo "Installing composer packages from $MY_PACKAGES_DIR"
     composer install --working-dir="$MY_PACKAGES_DIR" --no-interaction
 

--- a/lizmap.dir/etc/module-init.sh
+++ b/lizmap.dir/etc/module-init.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# Runs before the official lizmap-entrypoint.sh so that any module declared
+# in var/lizmap-my-packages/composer.json (e.g. the WebDAV module) is
+# installed and configured automatically, with no manual step required.
+#
+# Opt-in: only runs when LIZMAP_ENABLE_EXTRA_MODULES=1, so plain local setups
+# don't get extra modules unless they ask for it (see docker-compose.codespaces.yml
+# for the Codespaces override that turns it on).
+#
+# Note: `php configurator.php` (with no module name) does not reliably pick
+# up a module the very first time it is installed via Composer, so each
+# module found in the Composer-generated jelix_modules_infos.json is
+# configured explicitly by name.
+#
+# Idempotent: composer install is a no-op once vendor/ matches composer.lock,
+# and configurator.php skips modules that are already configured.
+#
+set -e
+
+MY_PACKAGES_DIR=/www/lizmap/my-packages
+
+if [ "${LIZMAP_ENABLE_EXTRA_MODULES:-0}" = "1" ] && [ -f "$MY_PACKAGES_DIR/composer.json" ]; then
+    echo "Installing composer packages from $MY_PACKAGES_DIR"
+    composer install --working-dir="$MY_PACKAGES_DIR" --no-interaction
+
+    if [ "$(id -u)" -eq "0" ]; then
+        UID_GID=${LIZMAP_USER:-1000}
+        chown -R "$UID_GID:$UID_GID" "$MY_PACKAGES_DIR"
+    fi
+
+    MODULES_INFOS="$MY_PACKAGES_DIR/vendor/jelix_modules_infos.json"
+    if [ -f "$MODULES_INFOS" ]; then
+        MODULES=$(php -r '
+            $data = json_decode(file_get_contents($argv[1]), true) ?: array();
+            $names = array();
+            foreach (($data["packages"] ?? array()) as $pkg) {
+                foreach (($pkg["modules"] ?? array()) as $modPath) {
+                    $names[] = basename($modPath);
+                }
+            }
+            echo implode(" ", array_unique($names));
+        ' "$MODULES_INFOS")
+
+        for module in $MODULES; do
+            echo "Configuring module: $module"
+            php /www/lizmap/install/configurator.php --no-interaction "$module"
+        done
+    fi
+fi
+
+exec /bin/lizmap-entrypoint.sh "$@"

--- a/lizmap.dir/etc/nginx.conf
+++ b/lizmap.dir/etc/nginx.conf
@@ -59,7 +59,9 @@ http {
         # and found a index.php file here
         location ~* /(\w+/)?\w+\.php {
 
-            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            # (/.*)$ (not /.+) so that trailing-slash-only URIs like /dav.php/
+            # (WebDAV root) still split correctly instead of 404ing.
+            fastcgi_split_path_info ^(.+\.php)(/.*)$;
             set $path_info $fastcgi_path_info; # because of bug http://trac.nginx.org/nginx/ticket/321
 
             try_files $fastcgi_script_name =404;

--- a/lizmap.dir/etc/nginx.conf
+++ b/lizmap.dir/etc/nginx.conf
@@ -43,6 +43,16 @@ http {
         https   443;
         http    80;
     }
+    # Some proxies/tunnels (e.g. GitHub Codespaces port forwarding) rewrite the
+    # Host header to an internal value (like "localhost:8090") before reaching
+    # us, and forward the real public host in X-Forwarded-Host instead. Code
+    # that reads $_SERVER['HTTP_HOST']/SERVER_NAME directly (not jelix's proxy-
+    # aware jServer helpers) — e.g. the WebDAV module's absolute URL used by the
+    # QGIS plugin — would otherwise point at that internal host and fail.
+    map $http_x_forwarded_host $lizmap_fcgi_host {
+        ''      $http_host;
+        default $http_x_forwarded_host;
+    }
 
     server {
         listen 8080;
@@ -69,7 +79,8 @@ http {
 
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            fastcgi_param SERVER_NAME $http_host;
+            fastcgi_param HTTP_HOST $lizmap_fcgi_host;
+            fastcgi_param SERVER_NAME $lizmap_fcgi_host;
             fastcgi_param SERVER_PORT $lizmap_fcgi_port;
             fastcgi_param HTTPS $lizmap_fcgi_https if_not_empty;
             fastcgi_param PATH_INFO $path_info;

--- a/lizmap.dir/var/lizmap-my-packages/composer.json
+++ b/lizmap.dir/var/lizmap-my-packages/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "lizmap/my-modules",
+    "type": "library",
+    "description": "Additional packages you want to use to enhance Lizmap",
+    "require": {
+        "jelix/composer-module-setup": "^1.1.0",
+        "lizmap/lizmap-webdav-module": "^1.2"
+    },
+    "extra": {
+        "jelix": {
+            "app-dir" : "../",
+            "var-config-dir" : "../var/config/"
+        }
+    },
+    "minimum-stability": "stable",
+    "config": {
+        "preferred-install": {
+            "*": "dist"
+        },
+        "allow-plugins": {
+            "jelix/composer-module-setup": true
+        }
+    }
+}

--- a/lizmap.dir/var/lizmap-my-packages/composer.lock
+++ b/lizmap.dir/var/lizmap-my-packages/composer.lock
@@ -1,0 +1,631 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "d2dbdc8156c313c9ed4e1642de6d4f7c",
+    "packages": [
+        {
+            "name": "jelix/composer-module-setup",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jelix/composer-module-setup.git",
+                "reference": "d0da3b64dd5249aab80b3907ef7957ddaf3b61d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jelix/composer-module-setup/zipball/d0da3b64dd5249aab80b3907ef7957ddaf3b61d3",
+                "reference": "d0da3b64dd5249aab80b3907ef7957ddaf3b61d3",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0.3",
+                "jelix/file-utilities": "1.8.*",
+                "phpunit/phpunit": "9.5.*"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Jelix\\ComposerPlugin\\ModuleSetup"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jelix\\ComposerPlugin\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Jouanneau",
+                    "email": "laurent@jelix.org"
+                }
+            ],
+            "description": "Plugin for Composer to declare Jelix modules automatically into a Jelix application",
+            "homepage": "http://jelix.org",
+            "keywords": [
+                "composer",
+                "composer-plugin",
+                "jelix"
+            ],
+            "support": {
+                "issues": "https://github.com/jelix/composer-module-setup/issues",
+                "source": "https://github.com/jelix/composer-module-setup/tree/1.1.0"
+            },
+            "time": "2022-10-12T14:08:10+00:00"
+        },
+        {
+            "name": "lizmap/lizmap-webdav-module",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/3liz/lizmap-webdav-module.git",
+                "reference": "0dd40f4b760bf07613819d48e46d494377355b87"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/3liz/lizmap-webdav-module/zipball/0dd40f4b760bf07613819d48e46d494377355b87",
+                "reference": "0dd40f4b760bf07613819d48e46d494377355b87",
+                "shasum": ""
+            },
+            "require": {
+                "sabre/dav": "~4.7.0"
+            },
+            "type": "jelix-module",
+            "extra": {
+                "jelix": {
+                    "modules": [
+                        "webdav/"
+                    ],
+                    "autoconfig-access-16": {
+                        "lizmap@3liz.com": {
+                            "webdav": {
+                                "index": 1,
+                                "__global": 1
+                            }
+                        }
+                    }
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "3Liz",
+                    "email": "info@3liz.com"
+                }
+            ],
+            "description": "Jelix module for Lizmap, enabling WebDAV.",
+            "homepage": "https://www.3liz.com/",
+            "keywords": [
+                "WebDAV",
+                "jelix",
+                "lizmap",
+                "module"
+            ],
+            "support": {
+                "issues": "https://github.com/3liz/lizmap-webdav-module/issues",
+                "source": "https://github.com/3liz/lizmap-webdav-module/tree/1.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.3liz.com/en/contacts.html",
+                    "type": "custom"
+                }
+            ],
+            "time": "2025-04-17T10:33:37+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "sabre/dav",
+            "version": "4.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/dav.git",
+                "reference": "f36f002dce082e1d425c4a0dc8c71a6b176c3b07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/dav/zipball/f36f002dce082e1d425c4a0dc8c71a6b176c3b07",
+                "reference": "f36f002dce082e1d425c4a0dc8c71a6b176c3b07",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-dom": "*",
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "ext-spl": "*",
+                "lib-libxml": ">=2.7.0",
+                "php": "^7.1.0 || ^8.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "sabre/event": "^5.0",
+                "sabre/http": "^5.0.5",
+                "sabre/uri": "^2.0",
+                "sabre/vobject": "^4.2.1",
+                "sabre/xml": "^2.0.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.19",
+                "monolog/monolog": "^1.27 || ^2.0",
+                "phpstan/phpstan": "^0.12 || ^1.0",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
+            },
+            "suggest": {
+                "ext-curl": "*",
+                "ext-imap": "*",
+                "ext-pdo": "*"
+            },
+            "bin": [
+                "bin/sabredav",
+                "bin/naturalselection"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Sabre\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "WebDAV Framework for PHP",
+            "homepage": "http://sabre.io/",
+            "keywords": [
+                "CalDAV",
+                "CardDAV",
+                "WebDAV",
+                "framework",
+                "iCalendar"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/dav/issues",
+                "source": "https://github.com/fruux/sabre-dav"
+            },
+            "time": "2026-07-07T08:39:09+00:00"
+        },
+        {
+            "name": "sabre/event",
+            "version": "5.1.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/event.git",
+                "reference": "743f1d04811fd5b89f67878d002f6a273ccb089f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/event/zipball/743f1d04811fd5b89f67878d002f6a273ccb089f",
+                "reference": "743f1d04811fd5b89f67878d002f6a273ccb089f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.17.1||^3.95",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/coroutine.php",
+                    "lib/Loop/functions.php",
+                    "lib/Promise/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Event\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "sabre/event is a library for lightweight event-based programming",
+            "homepage": "http://sabre.io/event/",
+            "keywords": [
+                "EventEmitter",
+                "async",
+                "coroutine",
+                "eventloop",
+                "events",
+                "hooks",
+                "plugin",
+                "promise",
+                "reactor",
+                "signal"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/event/issues",
+                "source": "https://github.com/fruux/sabre-event"
+            },
+            "time": "2026-07-07T09:13:04+00:00"
+        },
+        {
+            "name": "sabre/http",
+            "version": "5.1.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/http.git",
+                "reference": "7c2a14097d1a0de2347dcbdc91a02f38e338f4db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/http/zipball/7c2a14097d1a0de2347dcbdc91a02f38e338f4db",
+                "reference": "7c2a14097d1a0de2347dcbdc91a02f38e338f4db",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-curl": "*",
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabre/event": ">=4.0 <6.0",
+                "sabre/uri": "^2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.17.1||3.63.2",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
+            },
+            "suggest": {
+                "ext-curl": " to make http requests with the Client class"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\HTTP\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "The sabre/http library provides utilities for dealing with http requests and responses. ",
+            "homepage": "https://github.com/fruux/sabre-http",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/http/issues",
+                "source": "https://github.com/fruux/sabre-http"
+            },
+            "time": "2025-09-09T10:21:47+00:00"
+        },
+        {
+            "name": "sabre/uri",
+            "version": "2.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/uri.git",
+                "reference": "b76524c22de90d80ca73143680a8e77b1266c291"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/uri/zipball/b76524c22de90d80ca73143680a8e77b1266c291",
+                "reference": "b76524c22de90d80ca73143680a8e77b1266c291",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.63",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^1.12",
+                "phpstan/phpstan-phpunit": "^1.4",
+                "phpstan/phpstan-strict-rules": "^1.6",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Uri\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Functions for making sense out of URIs.",
+            "homepage": "http://sabre.io/uri/",
+            "keywords": [
+                "rfc3986",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/uri/issues",
+                "source": "https://github.com/fruux/sabre-uri"
+            },
+            "time": "2024-08-27T12:18:16+00:00"
+        },
+        {
+            "name": "sabre/vobject",
+            "version": "4.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/vobject.git",
+                "reference": "63613f6c53a0a2bddfe22caba0d052e6c59f7d0e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/vobject/zipball/63613f6c53a0a2bddfe22caba0d052e6c59f7d0e",
+                "reference": "63613f6c53a0a2bddfe22caba0d052e6c59f7d0e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabre/xml": "^2.1 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.17.1",
+                "phpstan/phpstan": "^0.12 || ^1.12 || ^2.0",
+                "phpunit/php-invoker": "^2.0 || ^3.1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
+            },
+            "suggest": {
+                "hoa/bench": "If you would like to run the benchmark scripts"
+            },
+            "bin": [
+                "bin/vobject",
+                "bin/generate_vcards"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sabre\\VObject\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Dominik Tobschall",
+                    "email": "dominik@fruux.com",
+                    "homepage": "http://tobschall.de/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net",
+                    "homepage": "http://mnt.io/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "The VObject library for PHP allows you to easily parse and manipulate iCalendar and vCard objects",
+            "homepage": "http://sabre.io/vobject/",
+            "keywords": [
+                "availability",
+                "freebusy",
+                "iCalendar",
+                "ical",
+                "ics",
+                "jCal",
+                "jCard",
+                "recurrence",
+                "rfc2425",
+                "rfc2426",
+                "rfc2739",
+                "rfc4770",
+                "rfc5545",
+                "rfc5546",
+                "rfc6321",
+                "rfc6350",
+                "rfc6351",
+                "rfc6474",
+                "rfc6638",
+                "rfc6715",
+                "rfc6868",
+                "vCalendar",
+                "vCard",
+                "vcf",
+                "xCal",
+                "xCard"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/vobject/issues",
+                "source": "https://github.com/fruux/sabre-vobject"
+            },
+            "time": "2026-07-07T03:20:17+00:00"
+        },
+        {
+            "name": "sabre/xml",
+            "version": "2.2.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/xml.git",
+                "reference": "01a7927842abf3e10df3d9c2d9b0cc9d813a3fcc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/xml/zipball/01a7927842abf3e10df3d9c2d9b0cc9d813a3fcc",
+                "reference": "01a7927842abf3e10df3d9c2d9b0cc9d813a3fcc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "lib-libxml": ">=2.6.20",
+                "php": "^7.1 || ^8.0",
+                "sabre/uri": ">=1.0,<3.0.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.17.1||3.63.2",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/Deserializer/functions.php",
+                    "lib/Serializer/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Xml\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Markus Staab",
+                    "email": "markus.staab@redaxo.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "sabre/xml is an XML library that you may not hate.",
+            "homepage": "https://sabre.io/xml/",
+            "keywords": [
+                "XMLReader",
+                "XMLWriter",
+                "dom",
+                "xml"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/xml/issues",
+                "source": "https://github.com/fruux/sabre-xml"
+            },
+            "time": "2024-09-06T07:37:46+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}


### PR DESCRIPTION
Declares the Lizmap WebDAV module in var/lizmap-my-packages/composer.json and installs/activates it automatically via a new entrypoint wrapper (lizmap.dir/etc/module-init.sh), gated behind LIZMAP_ENABLE_EXTRA_MODULES so plain local setups stay unaffected unless they opt in. The Codespaces compose override turns it on so the online demo gets WebDAV for free.

Also fixes the nginx fastcgi_split_path_info regex so the WebDAV root URL (/dav.php/, with a trailing slash and no further path) doesn't 404.