### PR TITLE
Inject a permissive referrer meta tag to keep OSM tiles from being bl…

### DIFF
--- a/lizmap.dir/etc/nginx.conf
+++ b/lizmap.dir/etc/nginx.conf
@@ -86,6 +86,19 @@ http {
             fastcgi_param PATH_INFO $path_info;
             fastcgi_param PATH_TRANSLATED $document_root$path_info;
             fastcgi_pass  lizmap:9000;
+
+            # Some proxies/tunnels in front of us (e.g. GitHub Codespaces port
+            # forwarding) inject a strict Referrer-Policy (e.g. "same-origin"),
+            # which suppresses the Referer header on requests to third-party
+            # tile servers (tile.openstreetmap.org). Without an identifiable
+            # Referer, OSM serves back a "blocked tile" placeholder image
+            # (see https://wiki.openstreetmap.org/wiki/Blocked_tiles).
+            # A <meta name="referrer"> tag in the page takes precedence over
+            # any Referrer-Policy header added upstream, so inject it directly
+            # into the HTML response instead of relying on a header that a
+            # proxy further down the chain could override.
+            sub_filter '<head>' '<head><meta name="referrer" content="strict-origin-when-cross-origin">';
+            sub_filter_once on;
         }
     }
 }


### PR DESCRIPTION
…ocked

Proxies/tunnels in front of Lizmap (e.g. GitHub Codespaces port forwarding) can inject a strict Referrer-Policy header (e.g. "same-origin"), which suppresses the Referer sent to third-party tile servers like tile.openstreetmap.org. Without an identifiable Referer, OSM serves back its "blocked tile" placeholder image instead of the actual tile (see https://wiki.openstreetmap.org/wiki/Blocked_tiles).

A <meta name="referrer"> tag takes precedence over any upstream Referrer-Policy header, so inject it into the HTML response via nginx sub_filter rather than relying on a header a proxy further down the chain could override.