### PR TITLE
Force port 8090 public on Codespaces start

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
   "name": "Lizmap Web Client",
   "image": "mcr.microsoft.com/devcontainers/base:bookworm",
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "onCreateCommand": "bash .devcontainer/setup.sh",
   "postStartCommand": "bash .devcontainer/setup.sh",

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -26,6 +26,15 @@ if [ -n "${CODESPACE_NAME:-}" ] && [ -n "${GITHUB_CODESPACES_PORT_FORWARDING_DOM
   export LIZMAP_PROXYURL_DOMAIN="${CODESPACE_NAME}-${LIZMAP_PORT}.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
 fi
 
+# devcontainer.json's portsAttributes.visibility isn't reliably honored by Codespaces
+# (see https://github.com/orgs/community/discussions/4068); set it imperatively too so
+# testers can open the map without a GitHub login.
+if [ -n "${CODESPACE_NAME:-}" ]; then
+  echo "▶ Making port ${LIZMAP_PORT} public…"
+  gh codespace ports visibility "${LIZMAP_PORT}:public" -c "$CODESPACE_NAME" \
+    || echo "  (couldn't set port visibility automatically — set it manually in the Ports tab, or check the org's Codespaces port-privacy policy)"
+fi
+
 if [ ! -f "$MARKER" ]; then
   echo "▶ Configuring Lizmap (first run, this happens only once)…"
 


### PR DESCRIPTION
devcontainer.json's portsAttributes.visibility isn't reliably honored by Codespaces, so the Lizmap web UI stayed private by default. Set it imperatively via `gh codespace ports visibility` in setup.sh as well, guarded so it's a no-op outside a real Codespace.